### PR TITLE
replace force_text with force_str.

### DIFF
--- a/django_mini_fastapi/route.py
+++ b/django_mini_fastapi/route.py
@@ -14,7 +14,7 @@ import re
 
 from pydantic import BaseModel, Field
 
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from .base import Request, Response
 
@@ -31,7 +31,7 @@ class RouteConfig(BaseModel):
 
 class RoutePath(object):
     def __init__(self, route_path: str):
-        route_path = force_text(route_path)
+        route_path = force_str(route_path)
         assert route_path.startswith("/")
 
         self.org_route_path = route_path


### PR DESCRIPTION
The smart_text() and force_text() aliases (since Django 2.0) of smart_str() and force_str() are deprecated. Ignore this deprecation if your code supports Python 2 as the behavior of smart_str() and force_str() is different there.

ref. https://docs.djangoproject.com/en/4.0/releases/3.0/#django-utils-encoding-force-text-and-smart-text